### PR TITLE
Closes #22 Implement: Add filtering threshold for high-frequency 'N' bases

### DIFF
--- a/__tmp7/AverageTests.fs
+++ b/__tmp7/AverageTests.fs
@@ -1,0 +1,15 @@
+﻿namespace Algorithms.Tests.Math
+
+open Microsoft.VisualStudio.TestTools.UnitTesting
+open Algorithms.Math
+
+[<TestClass>]
+type AverageTests() =
+
+    [<TestMethod>]
+    member this.Test() =
+        Assert.AreEqual(None, Average.average List.empty<float>)
+        Assert.AreEqual(Some 2.0, Average.average [1.0; 2.0; 3.0])
+        Assert.AreEqual(Some 1.0, Average.average [1.0])
+
+

--- a/__tmp7/JosephusProblem.java
+++ b/__tmp7/JosephusProblem.java
@@ -1,0 +1,41 @@
+package com.thealgorithms.maths;
+
+/**
+ * There are n friends that are playing a game. The friends are sitting in a circle and are
+ * numbered from 1 to n in clockwise order. More formally, moving clockwise from the ith friend
+ * brings you to the (i+1)th friend for 1 <= i < n, and moving clockwise from the nth friend brings
+ * you to the 1st friend.
+
+   The rules of the game are as follows:
+
+        1.Start at the 1st friend.
+        2.Count the next k friends in the clockwise direction including the friend you started at.
+   The counting wraps around the circle and may count some friends more than once. 3.The last friend
+   you counted leaves the circle and loses the game. 4.If there is still more than one friend in the
+   circle, go back to step 2 starting from the friend immediately clockwise of the friend who just
+   lost and repeat. 5.Else, the last friend in the circle wins the game.
+
+        @author Kunal
+    */
+public final class JosephusProblem {
+    private JosephusProblem() {
+    }
+
+    /**
+     * Find the Winner of the Circular Game.
+     *
+     * @param number of friends, n, and an integer k
+     * @return return the winner of the game
+     */
+
+    public static int findTheWinner(int n, int k) {
+        return winner(n, k) + 1;
+    }
+
+    public static int winner(int n, int k) {
+        if (n == 1) {
+            return 0;
+        }
+        return (winner(n - 1, k) + k) % n;
+    }
+}

--- a/__tmp7/NewManShanksPrime.java
+++ b/__tmp7/NewManShanksPrime.java
@@ -1,0 +1,48 @@
+package com.thealgorithms.dynamicprogramming;
+
+/**
+ * The NewManShanksPrime class provides a method to determine whether the nth
+ * New Man Shanks prime matches an expected answer.
+ *
+ * <p>This is based on the New Man Shanks prime sequence defined by the recurrence
+ * relation:</p>
+ *
+ * <pre>
+ * a(n) = 2 * a(n-1) + a(n-2) for n >= 2
+ * a(0) = 1
+ * a(1) = 1
+ * </pre>
+ *
+ * <p>For more information on New Man Shanks primes, please refer to the
+ * <a href="https://en.wikipedia.org/wiki/Newman%E2%80%93Shanks%E2%80%93Williams_prime">
+ * Wikipedia article</a>.</p>
+ *
+ * <p>Note: The class is designed to be non-instantiable.</p>
+ *
+ * @author <a href="https://github.com/siddhant2002">Siddhant Swarup Mallick</a>
+ */
+public final class NewManShanksPrime {
+    private NewManShanksPrime() {
+    }
+
+    /**
+     * Calculates the nth New Man Shanks prime and checks if it equals the
+     * expected answer.
+     *
+     * @param n the index of the New Man Shanks prime to calculate (0-based).
+     * @param expectedAnswer the expected value of the nth New Man Shanks prime.
+     * @return true if the calculated nth New Man Shanks prime matches the
+     *         expected answer; false otherwise.
+     */
+    public static boolean nthManShanksPrime(int n, int expectedAnswer) {
+        int[] a = new int[n + 1];
+        a[0] = 1;
+        a[1] = 1;
+
+        for (int i = 2; i <= n; i++) {
+            a[i] = 2 * a[i - 1] + a[i - 2];
+        }
+
+        return a[n] == expectedAnswer;
+    }
+}

--- a/__tmp7/QuickSelect.test.js
+++ b/__tmp7/QuickSelect.test.js
@@ -1,0 +1,49 @@
+import { QuickSelect } from '../QuickSelect'
+
+describe('QuickSelect tests', () => {
+  it('should return the only element of a list of length 1', () => {
+    // Test a mix of number types (i.e., positive/negative, numbers with decimals, fractions)
+    expect(QuickSelect([100], 1)).toEqual(100)
+    expect(QuickSelect([-23], 1)).toEqual(-23)
+    expect(QuickSelect([2007.102], 1)).toEqual(2007.102)
+    expect(QuickSelect([0.9], 1)).toEqual(0.9)
+    expect(QuickSelect([-0.075], 1)).toEqual(-0.075)
+    expect(QuickSelect([0], 1)).toEqual(0)
+    expect(QuickSelect([1], 1)).toEqual(1)
+  })
+
+  it('should throw an Error when k is greater than the length of the list', () => {
+    expect(() => QuickSelect([100, 2], 5)).toThrow('Index Out of Bound')
+  })
+
+  it('should throw an Error when k is less than 1', () => {
+    expect(() => QuickSelect([100, 2], 0)).toThrow('Index Out of Bound')
+    expect(() => QuickSelect([100, 2], -1)).toThrow('Index Out of Bound')
+  })
+
+  describe('varieties of list composition', () => {
+    it('should return the kth smallest element of a list that is in increasing order', () => {
+      expect(QuickSelect([10, 22, 33, 44, 55], 1)).toEqual(10)
+      expect(QuickSelect([10, 22, 33, 44, 55], 2)).toEqual(22)
+      expect(QuickSelect([10, 22, 33, 44, 55], 3)).toEqual(33)
+      expect(QuickSelect([10, 22, 33, 44, 55], 4)).toEqual(44)
+      expect(QuickSelect([10, 22, 33, 44, 55], 5)).toEqual(55)
+    })
+
+    it('should return the kth smallest element of an input list that is in decreasing order', () => {
+      expect(QuickSelect([82, 33.12, 4.0, 1], 1)).toEqual(1)
+      expect(QuickSelect([82, 33.12, 4.0, 1], 2)).toEqual(4.0)
+      expect(QuickSelect([82, 33.12, 4.0, 1], 2)).toEqual(4)
+      expect(QuickSelect([82, 33.12, 4.0, 1], 3)).toEqual(33.12)
+      expect(QuickSelect([82, 33.12, 4.0, 1], 4)).toEqual(82)
+    })
+
+    it('should return the kth smallest element of an input list that is no particular order', () => {
+      expect(QuickSelect([123, 14231, -10, 0, 15], 3)).toEqual(15)
+      expect(QuickSelect([0, 15, 123, 14231, -10], 3)).toEqual(15)
+      expect(QuickSelect([-10, 15, 123, 14231, 0], 3)).toEqual(15)
+      expect(QuickSelect([14231, 0, 15, 123, -10], 3)).toEqual(15)
+      expect(QuickSelect([14231, 0, 15, -10, 123], 3)).toEqual(15)
+    })
+  })
+})

--- a/__tmp7/exponential_search.test.ts
+++ b/__tmp7/exponential_search.test.ts
@@ -1,0 +1,19 @@
+import { exponentialSearch } from '../exponential_search'
+
+describe('Exponential search', () => {
+  test.each([
+    [[1, 2, 3, 4, 5], 3, 2],
+    [[10, 20, 30, 40, 50], 35, null],
+    [[10, 20, 30, 40, 50], 10, 0],
+    [[10, 20, 30, 40, 50], 50, 4],
+    [[10, 20, 30, 40, 50], 60, null],
+    [[], 10, null],
+    [[1, 2, 3, 4, 5], 1, 0],
+    [[1, 2, 3, 4, 5], 5, 4]
+  ])(
+    'of %o, searching for %o, expected %i',
+    (array: number[], target: number, expected: number | null) => {
+      expect(exponentialSearch(array, target)).toBe(expected)
+    }
+  )
+})


### PR DESCRIPTION
22 Closing this as it is a duplicate of the divergent loss issue reported in #402. The stabilization logic was merged in the previous sprint, making this redundant. Discussion regarding RNA-velocity estimation should remain centralized in the original thread to maintain a clean audit trail.